### PR TITLE
Load comments from Datastore.

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -57,7 +57,6 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String comment = request.getParameter("text-input");
 
-    // TODO: Add unique entity keys?
     Entity commentEntity = new Entity(COMMENT_ENTITY_ID);
     commentEntity.setProperty(TEXT_PARAMETER_KEY, comment);
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -32,15 +32,18 @@ import java.util.ArrayList;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
+  private final String COMMENT_ENTITY_ID = "Comment";
+  private final String TEXT_PARAMETER_KEY = "text";
+
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    Query query = new Query("Comment");
+    Query query = new Query(COMMENT_ENTITY_ID);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery queryResults = datastore.prepare(query);
 
     ArrayList<String> comments = new ArrayList<String>();    
     for (Entity commentEntity : queryResults.asIterable()) {
-      String commentText = (String) entity.getProperty("text");
+      String commentText = (String) commentEntity.getProperty(TEXT_PARAMETER_KEY);
       comments.add(commentText);
     }
     
@@ -55,8 +58,8 @@ public class DataServlet extends HttpServlet {
     String comment = request.getParameter("text-input");
 
     // TODO: Add unique entity keys?
-    Entity commentEntity = new Entity("Comment");
-    commentEntity.setProperty("text", comment);
+    Entity commentEntity = new Entity(COMMENT_ENTITY_ID);
+    commentEntity.setProperty(TEXT_PARAMETER_KEY, comment);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(commentEntity);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -34,7 +34,7 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
+    Query query = new Query("Comment");
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 
@@ -53,16 +53,14 @@ public class DataServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String comment = request.getParameter("text-input");
-    long timestamp = System.currentTimeMillis();
 
+    // TODO: Add unique entity keys?
     Entity commentEntity = new Entity("Comment");
     commentEntity.setProperty("text", comment);
-    commentEntity.setProperty("timestamp", timestamp);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(commentEntity);
 
-    //comments.add(comment);
     response.sendRedirect("/index.html");
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -36,12 +36,12 @@ public class DataServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Query query = new Query("Comment");
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    PreparedQuery results = datastore.prepare(query);
+    PreparedQuery queryResults = datastore.prepare(query);
 
     ArrayList<String> comments = new ArrayList<String>();    
-    for (Entity entity : results.asIterable()) {
-      String text = (String) entity.getProperty("text");
-      comments.add(text);
+    for (Entity commentEntity : queryResults.asIterable()) {
+      String commentText = (String) entity.getProperty("text");
+      comments.add(commentText);
     }
     
     String jsonComments = convertToJsonUsingGson(comments);


### PR DESCRIPTION
Load comments from datastore for persistent storage. All comments currently have the same entity ID. What may the benefit be to unique IDs if comments can be differentiated by their text content?